### PR TITLE
Add WordPress integration and React UI

### DIFF
--- a/seo_link_recommender/backend/tests/test_wp.py
+++ b/seo_link_recommender/backend/tests/test_wp.py
@@ -1,0 +1,43 @@
+import os
+import importlib
+import pytest
+import respx
+import httpx
+from httpx import AsyncClient, ASGITransport
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test.db"
+if os.path.exists("test.db"):
+    os.remove("test.db")
+from seo_link_recommender.backend.app import main
+importlib.reload(main)
+app = main.app
+import asyncio
+asyncio.get_event_loop().run_until_complete(main.on_startup())
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wp_recommend() -> None:
+    domain = "example.com"
+    respx.get("https://example.com/wp-json/wp/v2/posts?per_page=100").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"title": {"rendered": "Post1"}, "link": "https://example.com/post1"},
+                {"title": {"rendered": "Post2"}, "link": "https://example.com/post2"},
+            ],
+        )
+    )
+    respx.post("http://localhost:11434/api/generate").mock(
+        return_value=httpx.Response(
+            200,
+            json={"response": "https://example.com/post1 -> https://example.com/post2 | anchor"},
+        )
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/api/v1/wp_recommend", json={"domain": domain})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["recommendations"][0]["from"] == "https://example.com/post1"
+

--- a/seo_link_recommender/frontend/index.html
+++ b/seo_link_recommender/frontend/index.html
@@ -1,93 +1,111 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SEO Link Recommender</title>
-  <style>
-    body { font-family: sans-serif; margin: 0; padding: 0; background: #f5f5f5; }
-    .container { max-width: 800px; margin: 0 auto; padding: 20px; background: #fff; }
-    textarea { width: 100%; padding: 10px; box-sizing: border-box; resize: vertical; }
-    button { margin-top: 10px; padding: 8px 16px; }
-    h1 { text-align: center; }
-    section { margin-top: 20px; }
-    ul { list-style: disc; margin-left: 20px; padding-left: 0; }
-    .history-item { margin-bottom: 8px; }
-    .link-list a { color: #0645ad; text-decoration: none; }
-    .link-list a:hover { text-decoration: underline; }
-    #error { color: #b00020; }
-  </style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" />
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 </head>
 <body>
-  <div class="container">
-    <h1>SEO Link Recommender</h1>
-    <label for="text">Введите текст:</label>
-    <textarea id="text" rows="8" placeholder="Введите текст"></textarea>
-    <div>
-      <button id="send">Получить рекомендации</button>
-      <button id="load">Загрузить историю</button>
-    </div>
-    <p id="error" role="alert"></p>
+  <div id="app"></div>
+  <script type="text/babel">
+    function App() {
+      const [text, setText] = React.useState('');
+      const [domain, setDomain] = React.useState('');
+      const [links, setLinks] = React.useState([]);
+      const [history, setHistory] = React.useState([]);
+      const [error, setError] = React.useState('');
 
-    <section>
-      <h2>Результаты</h2>
-      <ul id="result" class="link-list"></ul>
-    </section>
+      React.useEffect(() => { loadHistory(); }, []);
 
-    <section>
-      <h2>История</h2>
-      <ul id="history"></ul>
-    </section>
-  </div>
-  <script>
-    async function updateHistory() {
-      const resp = await fetch('http://localhost:8000/api/v1/recommendations');
-      const data = await resp.json();
-      const history = document.getElementById('history');
-      history.innerHTML = '';
-      data.forEach(item => {
-        const li = document.createElement('li');
-        li.className = 'history-item';
-        li.textContent = item.text + ' \u2192 ' + (item.links || []).join(', ');
-        history.appendChild(li);
-      });
+      async function loadHistory() {
+        const resp = await fetch('http://localhost:8000/api/v1/recommendations');
+        const data = await resp.json();
+        setHistory(data);
+      }
+
+      async function sendText() {
+        if (!text.trim()) { setError('Поле не может быть пустым'); return; }
+        setError('');
+        const resp = await fetch('http://localhost:8000/api/v1/recommend', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text })
+        });
+        if (!resp.ok) { setError('Ошибка'); return; }
+        const data = await resp.json();
+        setLinks(data.links.map(l => ({ from: '', to: l, anchor: l })));
+        await loadHistory();
+      }
+
+      async function sendDomain() {
+        if (!domain.trim()) { setError('Поле не может быть пустым'); return; }
+        setError('');
+        const resp = await fetch('http://localhost:8000/api/v1/wp_recommend', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ domain })
+        });
+        if (!resp.ok) { setError('Ошибка'); return; }
+        const data = await resp.json();
+        setLinks(data.recommendations || []);
+      }
+
+      return (
+        <section className="section">
+          <div className="container">
+            <h1 className="title has-text-centered">SEO Link Recommender</h1>
+            <div className="box">
+              <div className="field">
+                <label className="label">Текст</label>
+                <div className="control">
+                  <textarea className="textarea" rows="4" value={text} onChange={e => setText(e.target.value)}></textarea>
+                </div>
+                <button className="button is-link mt-2" onClick={sendText}>Получить ссылки</button>
+              </div>
+              <div className="field mt-4">
+                <label className="label">WordPress сайт</label>
+                <div className="control">
+                  <input className="input" placeholder="example.com" value={domain} onChange={e => setDomain(e.target.value)} />
+                </div>
+                <button className="button is-primary mt-2" onClick={sendDomain}>Анализ WordPress</button>
+              </div>
+              {error && <p className="has-text-danger mt-2">{error}</p>}
+            </div>
+            <div className="content">
+              <h2>Рекомендации</h2>
+              <table className="table is-striped is-fullwidth">
+                <thead>
+                  <tr><th>Откуда</th><th>Куда</th><th>Анкор</th></tr>
+                </thead>
+                <tbody>
+                  {links.map((l, i) => (
+                    <tr key={i}>
+                      <td>{l.from ? <a href={l.from} target="_blank">{l.from}</a> : ''}</td>
+                      <td>{l.to ? <a href={l.to} target="_blank">{l.to}</a> : ''}</td>
+                      <td>{l.anchor}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="content">
+              <h2>История</h2>
+              <ul>
+                {history.map(h => (
+                  <li key={h.id}>{h.text} → {(h.links || []).join(', ')}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+      );
     }
 
-    document.getElementById('send').addEventListener('click', async () => {
-      const input = document.getElementById('text');
-      const text = input.value.trim();
-      const err = document.getElementById('error');
-      err.textContent = '';
-      if (!text) {
-        err.textContent = 'Поле не может быть пустым';
-        return;
-      }
-      const resp = await fetch('http://localhost:8000/api/v1/recommend', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text })
-      });
-      if (!resp.ok) {
-        err.textContent = 'Ошибка получения данных';
-        return;
-      }
-      const data = await resp.json();
-      const ul = document.getElementById('result');
-      ul.innerHTML = '';
-      (data.links || []).forEach(link => {
-        const li = document.createElement('li');
-        const a = document.createElement('a');
-        a.href = link;
-        a.textContent = link;
-        a.target = '_blank';
-        li.appendChild(a);
-        ul.appendChild(li);
-      });
-      await updateHistory();
-    });
-
-    document.getElementById('load').addEventListener('click', updateHistory);
-    document.addEventListener('DOMContentLoaded', updateHistory);
+    ReactDOM.createRoot(document.getElementById('app')).render(<App />);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow requesting interlinking suggestions for WordPress sites
- modernize frontend with React and Bulma
- support new `/api/v1/wp_recommend` endpoint
- add tests

## Testing
- `PYTHONPATH=. pytest -q seo_link_recommender/backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_685d9384e8cc83328f548056b9c8cbf0